### PR TITLE
Add tests for English rendering

### DIFF
--- a/friendly-time.cabal
+++ b/friendly-time.cabal
@@ -9,7 +9,7 @@ author:              Patrick Brisbin
 maintainer:          me@pbrisbin.com
 category:            Web, Yesod
 build-type:          Simple
-cabal-version:       >=1.6
+cabal-version:       >=1.8
 
 library
   exposed-modules: Data.Time.Format.Human
@@ -19,6 +19,17 @@ library
                , old-locale
 
   ghc-options: -Wall
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  hs-source-dirs: tests, .
+  main-is: tests/Main.hs
+  build-depends: HUnit
+               , test-framework
+               , test-framework-hunit
+               , base
+               , time
+               , old-locale
 
 source-repository head
   type:         git

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,0 +1,74 @@
+module Main where
+
+import Test.Framework
+import Test.Framework.Providers.HUnit
+
+import Test.HUnit
+
+import Data.Maybe (fromJust)
+import Data.Time.Clock
+import Data.Time.Format
+import Data.Time.Format.Human
+import System.Locale
+
+p :: String -> UTCTime
+p = fromJust . parseTime defaultTimeLocale "%F %T"
+
+helper :: String -> String -> String
+helper future past = humanReadableTime' (p future) (p past)
+
+testJustNow = "just now" @=? helper "2013-08-04 22:30:00"
+                                    "2013-08-04 22:30:00"
+
+testSecondsAgo = "13 seconds ago" @=? helper "2013-08-04 22:30:13"
+                                             "2013-08-04 22:30:00"
+
+testMinuteAgo = "one minute ago" @=? helper "2013-08-04 22:31:20"
+                                            "2013-08-04 22:30:00"
+
+testMinutesAgo = "10 minutes ago" @=? helper "2013-08-04 22:40:00"
+                                             "2013-08-04 22:30:00"
+
+testHourAgo = "one hour ago" @=? helper "2013-08-04 23:40:00"
+                                        "2013-08-04 22:30:00"
+
+testHoursAgo = "about 4 hours ago" @=? helper "2013-08-05 02:40:00"
+                                              "2013-08-04 22:30:00"
+
+testDow = "at 10:30 PM on Sunday" @=? helper "2013-08-08 10:10:10"
+                                             "2013-08-04 22:30:00"
+
+testDaysAgo = "6 days ago" @=? helper "2013-08-10 22:40:00"
+                                      "2013-08-04 22:30:00"
+
+testWeekAgo = "1 week ago" @=? helper "2013-08-16 22:40:00"
+                                      "2013-08-04 22:30:00"
+
+testWeeksAgo = "4 weeks ago" @=? helper "2013-09-04 22:40:00"
+                                        "2013-08-04 22:30:00"
+
+testThisYear = "on Aug  4" @=? helper "2013-11-04 22:40:00"
+                                       "2013-08-04 22:30:00"
+
+testPrevYear = "on Aug  4, 2013" @=? helper "2014-11-04 22:40:00"
+                                            "2013-08-04 22:30:00"
+
+tests = [
+    testGroup "English friendly time"
+        [ testCase "render now" testJustNow
+        , testCase "seconds ago" testSecondsAgo
+        , testCase "minute ago" testMinuteAgo
+        , testCase "minutes ago" testMinutesAgo
+        , testCase "hour ago" testHourAgo
+        , testCase "hours ago" testHoursAgo
+        , testCase "day of week" testDow
+        , testCase "days ago" testDaysAgo
+        , testCase "week ago" testWeekAgo
+        , testCase "weeks ago" testWeeksAgo
+        , testCase "this year" testThisYear
+        , testCase "previous year" testPrevYear
+        ]
+    ]
+
+main :: IO ()
+main = defaultMain tests


### PR DESCRIPTION
This commit also bumps required version of cabal to 1.8, which does not
choke on the test-suite section. However, to run the tests, at least
1.10 is required.
