### PR TITLE
Allow configuration of time zone

### DIFF
--- a/Data/Time/Format/Human.hs
+++ b/Data/Time/Format/Human.hs
@@ -42,6 +42,7 @@ data HumanTimeLocale = HumanTimeLocale
     , weeksAgo      :: String -> String
     , onYear        :: String -> String
     , locale        :: TimeLocale
+    , timeZone      :: TimeZone
     -- | Time format used with `at` member. See @Data.Time.Format@ for
     --   details on formatting  sequences.
     , dayOfWeekFmt  :: String
@@ -69,6 +70,7 @@ defaultHumanTimeLocale = HumanTimeLocale
     , weeksAgo      = (++ " weeks ago")
     , onYear        = ("on " ++)
     , locale        = defaultTimeLocale
+    , timeZone      = utc
     , dayOfWeekFmt  = "%l:%M %p on %A"
     , thisYearFmt   = "%b %e"
     , prevYearFmt   = "%b %e, %Y"
@@ -120,7 +122,7 @@ humanReadableTimeI18N' (HumanTimeLocale {..}) cur t = helper $ diffUTCTime cur t
         oldDayOfWeek :: Int
         oldDayOfWeek = read $ formatTime defaultTimeLocale "%u" t
 
-        old           = utcToLocalTime utc t
+        old           = utcToLocalTime timeZone t
         format        = formatTime locale
         dow           = trim $! format dayOfWeekFmt old
         thisYear      = trim $! format thisYearFmt old

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -17,6 +17,9 @@ p = fromJust . parseTime defaultTimeLocale "%F %T"
 helper :: String -> String -> String
 helper future past = humanReadableTime' (p future) (p past)
 
+helperI18N :: HumanTimeLocale -> String -> String -> String
+helperI18N ht future past = humanReadableTimeI18N' ht (p future) (p past)
+
 testJustNow = "just now" @=? helper "2013-08-04 22:30:00"
                                     "2013-08-04 22:30:00"
 
@@ -37,6 +40,16 @@ testHoursAgo = "about 4 hours ago" @=? helper "2013-08-05 02:40:00"
 
 testDow = "at 10:30 PM on Sunday" @=? helper "2013-08-08 10:10:10"
                                              "2013-08-04 22:30:00"
+
+testDowEDT = "at 6:30 PM on Sunday" @=?
+             helperI18N defaultHumanTimeLocale{timeZone=read "EDT"}
+             "2013-08-08 10:10:10"
+             "2013-08-04 22:30:00"
+
+testDowIndia = "at 4:00 AM on Monday" @=?
+             helperI18N defaultHumanTimeLocale{timeZone=read "+0530"}
+             "2013-08-08 10:10:10"
+             "2013-08-04 22:30:00"
 
 testDaysAgo = "6 days ago" @=? helper "2013-08-10 22:40:00"
                                       "2013-08-04 22:30:00"
@@ -62,6 +75,8 @@ tests = [
         , testCase "hour ago" testHourAgo
         , testCase "hours ago" testHoursAgo
         , testCase "day of week" testDow
+        , testCase "day of week in EDT" testDowEDT
+        , testCase "day of week in India" testDowIndia
         , testCase "days ago" testDaysAgo
         , testCase "week ago" testWeekAgo
         , testCase "weeks ago" testWeeksAgo


### PR DESCRIPTION
Sometimes we resort to printing the time with the day of week, as in "3:50 PM on Sunday". Previously, those times always used UTC. Now you can specify a `timeZone` in the `HumanTimeLocale` (default is still `utc`).

Includes two new test cases (with two different time zones).

[Independent of my previous pull request.]
Thanks!
