### PR TITLE
Add default Spanish human time locale

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -15,6 +15,7 @@ library:
   ghc-options: -Wall
   exposed-modules:
   - Data.Time.Format.Human
+  - Data.Time.Format.Human.Locales
   dependencies:
   - base >=4 && <5
 tests:

--- a/src/Data/Time/Format/Human.hs
+++ b/src/Data/Time/Format/Human.hs
@@ -143,3 +143,60 @@ humanReadableTimeI18N' (HumanTimeLocale {..}) cur t = helper $ diffUTCTime cur t
             | weeks d   < 5  = weeksAgo future $ i2s (weeks d)
             | years d   < 1  = onYear thisYear
             | otherwise      = onYear previousYears
+
+
+-- | Spanish human time locale.
+spanishHumanTimeLocale :: HumanTimeLocale
+spanishHumanTimeLocale = HumanTimeLocale
+    { justNow       = "Justo ahora"
+    , secondsAgo    = \f x -> (dir f ++ " " ++ x ++ " segundos")
+    , oneMinuteAgo  = \f -> dir f ++ " un minuto"
+    , minutesAgo    = \f x -> (dir f ++ " " ++ x ++ " minutos")
+    , oneHourAgo    = \f -> dir f ++ " una hora"
+    , aboutHoursAgo = \f x -> dir f ++ " aproximadamente " ++ x ++ " horas"
+    , at            = \_ -> ("El " ++)
+    , daysAgo       = \f x -> (dir f ++ " " ++ x ++ " dias")
+    , weekAgo       = \f x -> (dir f ++ " " ++ x ++ " semana")
+    , weeksAgo      = \f x -> (dir f ++ " " ++ x ++ " semanas")
+    , onYear        = ("En " ++)
+    , locale        = spanishTimeLocale
+    , timeZone      = utc
+    , dayOfWeekFmt  = "%A a las %l:%M %p"
+    , thisYearFmt   = "%b/%e"
+    , prevYearFmt   = "%Y/%b/%e"
+    }
+    where
+        dir True  = "Dentro de"
+        dir False = "Hace"
+        spanishTimeLocale = TimeLocale {
+            wDays  = [("Domingo", "Dom"),  ("Lunes",    "Lun"),
+                      ("Martes",    "Mar"),  ("Miercoles", "Mie"),
+                      ("Jueves",    "Jue"),  ("Viernes",    "Vie"),
+                      ("Sabado",    "Sab")],
+
+            months = [("Enero",    "Ene"), ("Febrero",  "Feb"),
+                    ("Marzo",      "Mar"), ("Abril",     "Abr"),
+                    ("Mayo",       "May"), ("Junio",      "Jun"),
+                    ("Julio",      "Jul"), ("Agosto",    "Ago"),
+                    ("Septiembre", "Sep"), ("Octubre",   "Oct"),
+                    ("Noviembre",  "Nov"), ("Diciembre",  "Dec")],
+
+            amPm = ("AM", "PM"),
+            dateTimeFmt = "%a %b %e %H:%M:%S %Z %Y",
+            dateFmt = "%y/%m/%d",
+            timeFmt = "%H:%M:%S",
+            time12Fmt = "%I:%M:%S %p",
+            knownTimeZones =
+                [
+                TimeZone 0 False "UT",
+                TimeZone 0 False "GMT",
+                TimeZone (-5 * 60) False "EST",
+                TimeZone (-4 * 60) True "EDT",
+                TimeZone (-6 * 60) False "CST",
+                TimeZone (-5 * 60) True "CDT",
+                TimeZone (-7 * 60) False "MST",
+                TimeZone (-6 * 60) True "MDT",
+                TimeZone (-8 * 60) False "PST",
+                TimeZone (-7 * 60) True "PDT"
+                ]
+            }

--- a/src/Data/Time/Format/Human.hs
+++ b/src/Data/Time/Format/Human.hs
@@ -143,5 +143,3 @@ humanReadableTimeI18N' (HumanTimeLocale {..}) cur t = helper $ diffUTCTime cur t
             | weeks d   < 5  = weeksAgo future $ i2s (weeks d)
             | years d   < 1  = onYear thisYear
             | otherwise      = onYear previousYears
-
-

--- a/src/Data/Time/Format/Human.hs
+++ b/src/Data/Time/Format/Human.hs
@@ -21,8 +21,6 @@ import Data.Char (isSpace)
 
 #if !MIN_VERSION_time(1,5,0)
 import System.Locale (TimeLocale, defaultTimeLocale)
-#else
-import Data.Time (TimeLocale, defaultTimeLocale)
 #endif
 
 

--- a/src/Data/Time/Format/Human.hs
+++ b/src/Data/Time/Format/Human.hs
@@ -16,6 +16,7 @@ module Data.Time.Format.Human
     ) where
 
 import Data.Time
+
 import Data.Char (isSpace)
 
 #if !MIN_VERSION_time(1,5,0)
@@ -74,7 +75,6 @@ defaultHumanTimeLocale = HumanTimeLocale
     }
     where dir True  = " from now"
           dir False = " ago"
-
 
 -- | Based on @humanReadableTimeDiff@ found in
 --   <https://github.com/snoyberg/haskellers/blob/master/Haskellers.hs>,

--- a/src/Data/Time/Format/Human.hs
+++ b/src/Data/Time/Format/Human.hs
@@ -21,6 +21,8 @@ import Data.Char (isSpace)
 
 #if !MIN_VERSION_time(1,5,0)
 import System.Locale (TimeLocale, defaultTimeLocale)
+#else
+import Data.Time (TimeLocale, defaultTimeLocale)
 #endif
 
 

--- a/src/Data/Time/Format/Human.hs
+++ b/src/Data/Time/Format/Human.hs
@@ -16,7 +16,6 @@ module Data.Time.Format.Human
     ) where
 
 import Data.Time
-
 import Data.Char (isSpace)
 
 #if !MIN_VERSION_time(1,5,0)
@@ -75,6 +74,7 @@ defaultHumanTimeLocale = HumanTimeLocale
     }
     where dir True  = " from now"
           dir False = " ago"
+
 
 -- | Based on @humanReadableTimeDiff@ found in
 --   <https://github.com/snoyberg/haskellers/blob/master/Haskellers.hs>,
@@ -145,58 +145,3 @@ humanReadableTimeI18N' (HumanTimeLocale {..}) cur t = helper $ diffUTCTime cur t
             | otherwise      = onYear previousYears
 
 
--- | Spanish human time locale.
-spanishHumanTimeLocale :: HumanTimeLocale
-spanishHumanTimeLocale = HumanTimeLocale
-    { justNow       = "Justo ahora"
-    , secondsAgo    = \f x -> (dir f ++ " " ++ x ++ " segundos")
-    , oneMinuteAgo  = \f -> dir f ++ " un minuto"
-    , minutesAgo    = \f x -> (dir f ++ " " ++ x ++ " minutos")
-    , oneHourAgo    = \f -> dir f ++ " una hora"
-    , aboutHoursAgo = \f x -> dir f ++ " aproximadamente " ++ x ++ " horas"
-    , at            = \_ -> ("El " ++)
-    , daysAgo       = \f x -> (dir f ++ " " ++ x ++ " dias")
-    , weekAgo       = \f x -> (dir f ++ " " ++ x ++ " semana")
-    , weeksAgo      = \f x -> (dir f ++ " " ++ x ++ " semanas")
-    , onYear        = ("En " ++)
-    , locale        = spanishTimeLocale
-    , timeZone      = utc
-    , dayOfWeekFmt  = "%A a las %l:%M %p"
-    , thisYearFmt   = "%b/%e"
-    , prevYearFmt   = "%Y/%b/%e"
-    }
-    where
-        dir True  = "Dentro de"
-        dir False = "Hace"
-        spanishTimeLocale = TimeLocale {
-            wDays  = [("Domingo", "Dom"),  ("Lunes",    "Lun"),
-                      ("Martes",    "Mar"),  ("Miercoles", "Mie"),
-                      ("Jueves",    "Jue"),  ("Viernes",    "Vie"),
-                      ("Sabado",    "Sab")],
-
-            months = [("Enero",    "Ene"), ("Febrero",  "Feb"),
-                    ("Marzo",      "Mar"), ("Abril",     "Abr"),
-                    ("Mayo",       "May"), ("Junio",      "Jun"),
-                    ("Julio",      "Jul"), ("Agosto",    "Ago"),
-                    ("Septiembre", "Sep"), ("Octubre",   "Oct"),
-                    ("Noviembre",  "Nov"), ("Diciembre",  "Dec")],
-
-            amPm = ("AM", "PM"),
-            dateTimeFmt = "%a %b %e %H:%M:%S %Z %Y",
-            dateFmt = "%y/%m/%d",
-            timeFmt = "%H:%M:%S",
-            time12Fmt = "%I:%M:%S %p",
-            knownTimeZones =
-                [
-                TimeZone 0 False "UT",
-                TimeZone 0 False "GMT",
-                TimeZone (-5 * 60) False "EST",
-                TimeZone (-4 * 60) True "EDT",
-                TimeZone (-6 * 60) False "CST",
-                TimeZone (-5 * 60) True "CDT",
-                TimeZone (-7 * 60) False "MST",
-                TimeZone (-6 * 60) True "MDT",
-                TimeZone (-8 * 60) False "PST",
-                TimeZone (-7 * 60) True "PDT"
-                ]
-            }

--- a/src/Data/Time/Format/Human/Locales.hs
+++ b/src/Data/Time/Format/Human/Locales.hs
@@ -1,0 +1,62 @@
+module Data.Time.Format.Human.Locales
+    ( spanishHumanTimeLocale
+    ) where
+
+import Data.Time
+import Data.Time.Format.Human
+
+-- | Spanish human time locale.
+spanishHumanTimeLocale :: HumanTimeLocale
+spanishHumanTimeLocale = HumanTimeLocale
+    { justNow       = "Justo ahora"
+    , secondsAgo    = \f x -> (dir f ++ " " ++ x ++ " segundos")
+    , oneMinuteAgo  = \f -> dir f ++ " un minuto"
+    , minutesAgo    = \f x -> (dir f ++ " " ++ x ++ " minutos")
+    , oneHourAgo    = \f -> dir f ++ " una hora"
+    , aboutHoursAgo = \f x -> dir f ++ " aproximadamente " ++ x ++ " horas"
+    , at            = \_ -> ("El " ++)
+    , daysAgo       = \f x -> (dir f ++ " " ++ x ++ " dias")
+    , weekAgo       = \f x -> (dir f ++ " " ++ x ++ " semana")
+    , weeksAgo      = \f x -> (dir f ++ " " ++ x ++ " semanas")
+    , onYear        = ("En " ++)
+    , locale        = spanishTimeLocale
+    , timeZone      = utc
+    , dayOfWeekFmt  = "%A a las %l:%M %p"
+    , thisYearFmt   = "%b/%e"
+    , prevYearFmt   = "%Y/%b/%e"
+    }
+    where
+        dir True  = "Dentro de"
+        dir False = "Hace"
+        spanishTimeLocale = TimeLocale {
+            wDays  = [("Domingo", "Dom"),  ("Lunes",    "Lun"),
+                      ("Martes",    "Mar"),  ("Miercoles", "Mie"),
+                      ("Jueves",    "Jue"),  ("Viernes",    "Vie"),
+                      ("Sabado",    "Sab")],
+
+            months = [("Enero",    "Ene"), ("Febrero",  "Feb"),
+                    ("Marzo",      "Mar"), ("Abril",     "Abr"),
+                    ("Mayo",       "May"), ("Junio",      "Jun"),
+                    ("Julio",      "Jul"), ("Agosto",    "Ago"),
+                    ("Septiembre", "Sep"), ("Octubre",   "Oct"),
+                    ("Noviembre",  "Nov"), ("Diciembre",  "Dec")],
+
+            amPm = ("AM", "PM"),
+            dateTimeFmt = "%a %b %e %H:%M:%S %Z %Y",
+            dateFmt = "%y/%m/%d",
+            timeFmt = "%H:%M:%S",
+            time12Fmt = "%I:%M:%S %p",
+            knownTimeZones =
+                [
+                TimeZone 0 False "UT",
+                TimeZone 0 False "GMT",
+                TimeZone (-5 * 60) False "EST",
+                TimeZone (-4 * 60) True "EDT",
+                TimeZone (-6 * 60) False "CST",
+                TimeZone (-5 * 60) True "CDT",
+                TimeZone (-7 * 60) False "MST",
+                TimeZone (-6 * 60) True "MDT",
+                TimeZone (-8 * 60) False "PST",
+                TimeZone (-7 * 60) True "PDT"
+                ]
+            }


### PR DESCRIPTION
Not sure if adding default time locales for various languages is the right way to go, but the Yesod web framework seems to include them, and it's actually nice to have when i18n is required.

The idea is to include a couple of languages out of the box, if this PR is useful, other contributors may implement defaults for other languages as well hopefully.

If this is however not kind of stuff the package aims to provide, please feel free to dismiss this PR.

pd: I'm a native Spanish speaker so i'm sure this default makes sense (already tried it)